### PR TITLE
fix: auto-select admin-configured single request options

### DIFF
--- a/doplarr/src/providers/mod.rs
+++ b/doplarr/src/providers/mod.rs
@@ -96,10 +96,17 @@ pub struct SuccessMessage {
 
 impl RequestDetails {
     /// Returns the currently selected option (for single-select fields).
+    ///
+    /// When only one option exists (admin-configured default), it is treated as
+    /// selected even if the user was not prompted to choose from a dropdown.
     pub fn selected_option(&self) -> Option<&DropdownOption> {
-        self.selected_indices
-            .first()
-            .and_then(|&i| self.options.get(i))
+        if let Some(&i) = self.selected_indices.first() {
+            return self.options.get(i);
+        }
+        if self.options.len() == 1 {
+            return self.options.first();
+        }
+        None
     }
 
     /// Returns all currently selected options (for multi-select fields).
@@ -152,4 +159,68 @@ pub trait MediaBackend: Send + Sync {
 
     /// Build the success message including details about what was requested
     fn success_message(&self, details: &[RequestDetails], media: &dyn MediaItem) -> SuccessMessage;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_option(title: &str) -> DropdownOption {
+        DropdownOption {
+            title: title.to_string(),
+            description: None,
+            id: None,
+        }
+    }
+
+    #[test]
+    fn selected_option_uses_explicit_selection() {
+        let detail = RequestDetails {
+            title: "Root Folder".to_string(),
+            options: vec![
+                sample_option("/movies"),
+                sample_option("/movies/4k"),
+            ],
+            selected_indices: vec![1],
+            metadata: None,
+            field_type: FieldType::Dropdown,
+            always_show: false,
+        };
+
+        assert_eq!(detail.selected_option().unwrap().title, "/movies/4k");
+    }
+
+    #[test]
+    fn selected_option_defaults_to_single_admin_configured_option() {
+        let detail = RequestDetails {
+            title: "Root Folder".to_string(),
+            options: vec![sample_option("/data/media/movies")],
+            selected_indices: vec![],
+            metadata: None,
+            field_type: FieldType::Dropdown,
+            always_show: false,
+        };
+
+        assert_eq!(
+            detail.selected_option().unwrap().title,
+            "/data/media/movies"
+        );
+    }
+
+    #[test]
+    fn selected_option_requires_selection_when_multiple_options() {
+        let detail = RequestDetails {
+            title: "Root Folder".to_string(),
+            options: vec![
+                sample_option("/movies"),
+                sample_option("/movies/4k"),
+            ],
+            selected_indices: vec![],
+            metadata: None,
+            field_type: FieldType::Dropdown,
+            always_show: false,
+        };
+
+        assert!(detail.selected_option().is_none());
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #10 — movie requests failed with "No option was selected for 'Root Folder'" when `config.toml` pre-configured fields to a single option (root folder, quality profile, monitor, etc.)
- The Discord UI correctly treated these as admin defaults (shown as text, no dropdown), but `RequestDetails::selected_option()` only looked at `selected_indices`, which stayed empty
- Single-option fields are now implicitly selected; multi-option fields still require an explicit user choice
- Added unit tests for the three selection cases

## Test plan
- [x] `cargo test -p doplarr providers::tests`
- [x] `cargo test -p doplarr`
- [ ] Request a movie with all Radarr options pre-configured in `config.toml` (rootfolder, quality_profile, monitor_type, minimum_availability) and confirm the request succeeds without selecting from dropdowns

---
This fix was implemented using [Cursor](https://cursor.com) and reviewed by @mon5termatt.

Made with [Cursor](https://cursor.com)